### PR TITLE
[canvas] added Render() tests+benchmark

### DIFF
--- a/pkg/canvas/canvas.go
+++ b/pkg/canvas/canvas.go
@@ -2,7 +2,7 @@ package canvas
 
 import (
 	"fmt"
-	"os"
+	"io"
 	"runtime"
 )
 
@@ -15,7 +15,7 @@ type Canvas interface {
 
 // TermCanvas represents what is actually rendered to the user via the terminal
 type TermCanvas struct {
-	dest       *os.File
+	dest       io.Writer
 	Background Color
 	cells      [][]Cell
 	debugMode  bool
@@ -23,7 +23,7 @@ type TermCanvas struct {
 
 // Config represents the configuration params for a terminal canvas
 type Config struct {
-	Term       *os.File
+	Term       io.Writer
 	Width      int
 	Height     int
 	Background Color
@@ -107,7 +107,7 @@ func resetString() string {
 }
 
 func (c *TermCanvas) clear() error {
-	_, err := c.dest.WriteString(resetString())
+	_, err := c.dest.Write([]byte(resetString()))
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (c *TermCanvas) clear() error {
 }
 
 func (c *TermCanvas) setCursor(x, y int) error {
-	_, err := c.dest.WriteString(fmt.Sprintf("\033[%d;%dH", x, y))
+	_, err := c.dest.Write([]byte(fmt.Sprintf("\033[%d;%dH", x, y)))
 	if err != nil {
 		return err
 	}

--- a/pkg/canvas/canvas_test.go
+++ b/pkg/canvas/canvas_test.go
@@ -1,0 +1,151 @@
+package canvas
+
+import (
+	"bytes"
+	"testing"
+)
+
+var renderTests = map[string]struct {
+	width            int
+	height           int
+	background       Color
+	debugMode        bool
+	cells            [][]Cell
+	expectedContents string
+}{
+	"2x2 no update, debugMode": {
+		width:            2,
+		height:           2,
+		background:       White,
+		debugMode:        true,
+		expectedContents: "\u001b[37m\u2588\u001b[37m\u2588\n\u001b[0m\u001b[37m\u2588\u001b[37m\u2588\n\u001b[0m\u001b[0m",
+	},
+	"2x2 update cells": {
+		width:      2,
+		height:     2,
+		background: Blue,
+		cells: [][]Cell{
+			{&BlockCell{Color: White}, &BlockCell{Color: White}},
+			{&BlockCell{Color: White}, &BlockCell{Color: White}},
+		},
+		expectedContents: "\x1b[0;0H\u001b[47m\u001b[37m\u2588\u001b[47m\u001b[37m\u2588\n\u001b[0m\u001b[47m\u001b[37m\u2588\u001b[47m\u001b[37m\u2588\n\u001b[0m\u001b[0m",
+	},
+}
+
+func TestRender(t *testing.T) {
+	for testName, test := range renderTests {
+		var b bytes.Buffer
+		c := New(Config{
+			Term:       &b,
+			Width:      test.width,
+			Height:     test.height,
+			Background: test.background,
+			DebugMode:  test.debugMode,
+		})
+
+		if len(test.cells) != 0 {
+			c.UpdateCells(test.cells)
+		}
+
+		err := c.Render()
+		if err != nil {
+			t.Fatalf("Unexpected error rendering canvas for test case '%s'", testName)
+		}
+
+		contents := b.String()
+		if contents != test.expectedContents {
+			t.Errorf("Unexpected contents for test case '%s' [expected = %#v, actual = %#v]", testName, test.expectedContents, contents)
+		}
+	}
+}
+
+var renderBenchmarks = []struct {
+	name  string
+	size  int
+	cells [][]Cell
+}{
+	{
+		name: "4x4 no updates",
+		size: 4,
+	},
+	{
+		name:  "4x4 update non-transparent",
+		size:  4,
+		cells: populateCells(4, false),
+	},
+	{
+		name:  "4x4 update transparent",
+		size:  4,
+		cells: populateCells(4, true),
+	},
+	{
+		name:  "10x10 update transparent",
+		size:  10,
+		cells: populateCells(10, true),
+	},
+	{
+		name:  "20x20 update transparent",
+		size:  20,
+		cells: populateCells(20, true),
+	},
+	{
+		name:  "50x50 update transparent",
+		size:  50,
+		cells: populateCells(50, true),
+	},
+	{
+		name:  "100x100 update transparent",
+		size:  100,
+		cells: populateCells(100, true),
+	},
+}
+
+var benchRes error
+
+func BenchmarkRender(b *testing.B) {
+	for _, benchmark := range renderBenchmarks {
+		var (
+			buf   bytes.Buffer
+			size  = benchmark.size
+			cells = benchmark.cells
+			name  = benchmark.name
+		)
+		c := New(Config{
+			Term:       &buf,
+			Width:      size,
+			Height:     size,
+			Background: White,
+			DebugMode:  false,
+		})
+		if len(cells) != 0 {
+			c.UpdateCells(cells)
+		}
+
+		b.Run(name, func(b *testing.B) {
+			var err error
+			for n := 0; n < b.N; n++ {
+				err = c.Render()
+				if err != nil {
+					b.Errorf("Error rendering canvas: %s", err)
+				}
+			}
+			benchRes = err
+		})
+	}
+}
+
+// generates grid of cells for testing
+func populateCells(size int, transparent bool) [][]Cell {
+	cells := make([][]Cell, size)
+	for i := range cells {
+		row := make([]Cell, size)
+		for j := range row {
+			row[j] = &BlockCell{
+				Color:       Blue,
+				Transparent: transparent,
+			}
+		}
+		cells[i] = row
+	}
+	return cells
+}


### PR DESCRIPTION
Trying to get an idea of how performance can be improved so I've added a few benchmarks for the current implementation of `TermCanvas.Render()` to get a base reference. As it stands the benchmarks are:
```
BenchmarkRender/4x4_no_updates-4                  100000             13203 ns/op
BenchmarkRender/4x4_update_non-transparent-4              100000             24844 ns/op
BenchmarkRender/4x4_update_transparent-4                  100000             17370 ns/op
BenchmarkRender/10x10_update_transparent-4                 10000            103072 ns/op
BenchmarkRender/20x20_update_transparent-4                  3000            400629 ns/op
BenchmarkRender/50x50_update_transparent-4                   500           2469513 ns/op
BenchmarkRender/100x100_update_transparent-4                 200          10233435 ns/op
```