### PR TITLE
[canvas] small optimizations to Render

### DIFF
--- a/pkg/canvas/canvas.go
+++ b/pkg/canvas/canvas.go
@@ -59,7 +59,7 @@ func (c *TermCanvas) Render() error {
 	var b bytes.Buffer
 	if !c.debugMode {
 		// reset cursor
-		b.Write(c.setCursor(0, 0))
+		b.Write(resetTermCursor)
 	}
 
 	for _, row := range c.cells {
@@ -71,10 +71,10 @@ func (c *TermCanvas) Render() error {
 			}
 			b.WriteString(cell.String())
 		}
-		b.WriteString("\n")
-		b.WriteString(Reset.String())
+		b.WriteByte('\n')
+		b.Write(resetControl)
 	}
-	b.WriteString(Reset.String())
+	b.Write(resetControl)
 
 	// clear any potential formatting
 	_, err := c.dest.Write(b.Bytes())
@@ -104,6 +104,8 @@ func (c *TermCanvas) clear() error {
 	}
 	return nil
 }
+
+var resetTermCursor = []byte{'\x1b', '[', '0', ';', '0', 'H'}
 
 func (c *TermCanvas) setCursor(x, y int) []byte {
 	var b bytes.Buffer

--- a/pkg/canvas/colors.go
+++ b/pkg/canvas/colors.go
@@ -46,8 +46,11 @@ const (
 	BackgroundOrange Color = -208
 )
 
+var resetControl = []byte{'\u001b', '[', '0', 'm'}
+
 func (c Color) String() string {
 	var b strings.Builder
+	b.Grow(5)
 	b.WriteString("\u001b[")
 	switch c {
 	case BrightBlack, BrightRed, BrightGreen, BrightYellow, BrightBlue, BrightMagenta, BrightCyan, BrightWhite:
@@ -107,6 +110,7 @@ func (c Color) description() string {
 // decorate formats the provided input so it can be printed in color
 func (c Color) decorate(input string) string {
 	var b strings.Builder
+	b.Grow(13)
 	b.WriteString(c.String())
 	b.WriteString(input)
 	return b.String()


### PR DESCRIPTION
As a follow up to #3 I've made a few small changes to improve the performance of rendering the canvas. Primarily these involved reducing the number of times we wrote directly to the terminal and migrating from `fmt.Sprintf()` for string construction. After these changes the benchmarks now are: 
```
BenchmarkRender/4x4_no_updates-4                 1000000              1631 ns/op
BenchmarkRender/4x4_update_non-transparent-4              500000              3331 ns/op
BenchmarkRender/4x4_update_transparent-4                  500000              3313 ns/op
BenchmarkRender/10x10_update_transparent-4                100000             19309 ns/op
BenchmarkRender/20x20_update_transparent-4                 20000             73616 ns/op
BenchmarkRender/50x50_update_transparent-4                  3000            455996 ns/op
BenchmarkRender/100x100_update_transparent-4                1000           1879153 ns/op
```