### PR TITLE
[game] render canvas in separate go routine

### DIFF
--- a/internal/game/canvas.go
+++ b/internal/game/canvas.go
@@ -1,0 +1,47 @@
+package game
+
+import (
+	"sync"
+
+	"github.com/ShawnROGrady/gotris/internal/canvas"
+)
+
+// gCanvas wraps a standard canvas
+type gCanvas struct {
+	canvas    canvas.Canvas
+	newCells  chan [][]canvas.Cell
+	mut       *sync.Mutex
+	renderErr error
+}
+
+func (g *gCanvas) run(done <-chan bool) {
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case cells := <-g.newCells:
+				g.mut.Lock()
+				g.canvas.UpdateCells(cells)
+				if err := g.canvas.Render(); err != nil {
+					g.renderErr = err
+				}
+				g.mut.Unlock()
+			}
+		}
+	}()
+}
+
+func (g *gCanvas) Init() error {
+	return g.canvas.Init()
+}
+
+func (g *gCanvas) UpdateCells(newCells [][]canvas.Cell) {
+	g.newCells <- newCells
+}
+
+func (g *gCanvas) Render() error {
+	g.mut.Lock()
+	defer g.mut.Unlock()
+	return g.renderErr
+}


### PR DESCRIPTION
Added a wrapper to the standard canvas in order to perform canvas rendering in separate go routine. After running the benchmark a few more times:
```
BEFORE:
no-race: 330796 ns/op
race: 2281012 ns/op

AFTER:
no-race: 290654 ns/op 
race: 1911776 ns/op
```

**NOTE:** the results from #6 were performed without the `-race` flag. I wasn't aware adding this flag made such a difference in the benchmark results.