### PR TITLE
[canvas] cache cell strings

### DIFF
--- a/internal/canvas/canvas_test.go
+++ b/internal/canvas/canvas_test.go
@@ -69,32 +69,62 @@ var renderBenchmarks = []struct {
 	{
 		name:  "4x4 update non-transparent",
 		size:  4,
-		cells: populateCells(4, false),
+		cells: populateCells(4, false, false),
 	},
 	{
 		name:  "4x4 update transparent",
 		size:  4,
-		cells: populateCells(4, true),
+		cells: populateCells(4, true, false),
 	},
 	{
 		name:  "10x10 update transparent",
 		size:  10,
-		cells: populateCells(10, true),
+		cells: populateCells(10, true, false),
 	},
 	{
 		name:  "20x20 update transparent",
 		size:  20,
-		cells: populateCells(20, true),
+		cells: populateCells(20, true, false),
 	},
 	{
 		name:  "50x50 update transparent",
 		size:  50,
-		cells: populateCells(50, true),
+		cells: populateCells(50, true, false),
 	},
 	{
 		name:  "100x100 update transparent",
 		size:  100,
-		cells: populateCells(100, true),
+		cells: populateCells(100, true, false),
+	},
+	{
+		name:  "4x4 boxed update non-transparent",
+		size:  4,
+		cells: populateCells(4, false, true),
+	},
+	{
+		name:  "4x4 boxed update transparent",
+		size:  4,
+		cells: populateCells(4, true, true),
+	},
+	{
+		name:  "10x10 boxed update transparent",
+		size:  10,
+		cells: populateCells(10, true, true),
+	},
+	{
+		name:  "20x20 boxed update transparent",
+		size:  20,
+		cells: populateCells(20, true, true),
+	},
+	{
+		name:  "50x50 boxed update transparent",
+		size:  50,
+		cells: populateCells(50, true, true),
+	},
+	{
+		name:  "100x100 boxed update transparent",
+		size:  100,
+		cells: populateCells(100, true, true),
 	},
 }
 
@@ -128,17 +158,21 @@ func BenchmarkRender(b *testing.B) {
 }
 
 // generates grid of cells for testing
-func populateCells(size int, transparent bool) [][]Cell {
+func populateCells(size int, transparent bool, box bool) [][]Cell {
+	colors := []Color{Black, Red, Green, Yellow, Blue, Magenta, Cyan, White}
 	cells := make([][]Cell, size)
 	for i := range cells {
 		row := make([]Cell, size)
 		for j := range row {
 			row[j] = &BlockCell{
-				Color:       Blue,
+				Color:       colors[(i+j)%len(colors)],
 				Transparent: transparent,
 			}
 		}
 		cells[i] = row
+	}
+	if box {
+		return Box(cells, "TEST")
 	}
 	return cells
 }

--- a/internal/canvas/cell.go
+++ b/internal/canvas/cell.go
@@ -1,8 +1,25 @@
 package canvas
 
 import (
+	"strconv"
 	"strings"
 )
+
+const (
+	blockCellType = iota
+	pipeCellType
+	textCellType
+)
+
+func cellTypes() []int {
+	return []int{blockCellType, pipeCellType, textCellType}
+}
+
+// Cell represents an item to be rendered on the canvas
+type Cell interface {
+	String() string
+	hash() (int, string)
+}
 
 const (
 	// block elements
@@ -19,11 +36,6 @@ const (
 	bottomLeftPipe    = "\u255A"
 	bottomRightPipe   = "\u255D"
 )
-
-// Cell represents an item to be rendered on the canvas
-type Cell interface {
-	String() string
-}
 
 // BlockCell represents a single cell on the canvas
 type BlockCell struct {
@@ -42,6 +54,25 @@ func (c *BlockCell) String() string {
 	return c.Color.background().decorate(
 		c.Color.decorate(block),
 	)
+}
+
+func (c *BlockCell) hash() (int, string) {
+	var b strings.Builder
+	col := strconv.Itoa(int(c.Color))
+	b.WriteString(col)
+	b.WriteString("_")
+
+	back := strconv.Itoa(int(c.Background))
+	b.WriteString(back)
+	b.WriteString("_")
+
+	if c.Transparent {
+		b.WriteString("1")
+	} else {
+		b.WriteString("0")
+	}
+
+	return blockCellType, b.String()
 }
 
 // PipeType represents a type of pipe cell
@@ -80,6 +111,18 @@ func (p *PipeCell) String() string {
 	default:
 		return ""
 	}
+}
+
+func (p *PipeCell) hash() (int, string) {
+	var b strings.Builder
+	col := strconv.Itoa(int(p.Color))
+	b.WriteString(col)
+	b.WriteString("_")
+
+	t := strconv.Itoa(int(p.Type))
+	b.WriteString(t)
+
+	return pipeCellType, b.String()
 }
 
 // Box wraps a block of cells in a piped box
@@ -152,6 +195,18 @@ type TextCell struct {
 
 func (t *TextCell) String() string {
 	return t.Color.decorate(t.Text)
+}
+
+func (t *TextCell) hash() (int, string) {
+	var b strings.Builder
+
+	col := strconv.Itoa(int(t.Color))
+	b.WriteString(col)
+	b.WriteString("_")
+
+	b.WriteString(t.Text)
+
+	return textCellType, b.String()
 }
 
 // CellsFromString constructs a grid of TextCells from a provided string


### PR DESCRIPTION
Added some basic caching for the string representations of cells. Also improved benchmarks to include pipe and text cells. Results:

BEFORE:
```
BenchmarkRender/4x4_no_updates-4                   50000             25880 ns/op
BenchmarkRender/4x4_update_non-transparent-4               30000             58155 ns/op
BenchmarkRender/4x4_update_transparent-4                   30000             57210 ns/op
BenchmarkRender/10x10_update_transparent-4                  5000            347892 ns/op
BenchmarkRender/20x20_update_transparent-4                  1000           1321545 ns/op
BenchmarkRender/50x50_update_transparent-4                   200           8150690 ns/op
BenchmarkRender/100x100_update_transparent-4                  50          32910036 ns/op
BenchmarkRender/4x4_boxed_update_non-transparent-4         20000             94382 ns/op
BenchmarkRender/4x4_boxed_update_transparent-4             20000             93629 ns/op
BenchmarkRender/10x10_boxed_update_transparent-4            3000            416489 ns/op
BenchmarkRender/20x20_boxed_update_transparent-4            1000           1471571 ns/op
BenchmarkRender/50x50_boxed_update_transparent-4             200           8483265 ns/op
BenchmarkRender/100x100_boxed_update_transparent-4            50          33050809 ns/op
```

AFTER:
```
BenchmarkRender/4x4_no_updates-4                   50000             25798 ns/op
BenchmarkRender/4x4_update_non-transparent-4               50000             30297 ns/op
BenchmarkRender/4x4_update_transparent-4                   50000             32276 ns/op
BenchmarkRender/10x10_update_transparent-4                 10000            176013 ns/op
BenchmarkRender/20x20_update_transparent-4                  2000            675142 ns/op
BenchmarkRender/50x50_update_transparent-4                   300           4046671 ns/op
BenchmarkRender/100x100_update_transparent-4                 100          16444711 ns/op
BenchmarkRender/4x4_boxed_update_non-transparent-4         30000             57244 ns/op
BenchmarkRender/4x4_boxed_update_transparent-4             30000             55932 ns/op
BenchmarkRender/10x10_boxed_update_transparent-4            5000            227881 ns/op
BenchmarkRender/20x20_boxed_update_transparent-4            2000            785008 ns/op
BenchmarkRender/50x50_boxed_update_transparent-4             300           4447274 ns/op
BenchmarkRender/100x100_boxed_update_transparent-4           100          17448057 ns/op
```

Overall the `20x20_boxed_update_transparent` case is the most accurate representation of the actual use case, which means the caching resulted in a roughly 85% reduction in cpu time.